### PR TITLE
Fix label for tl_content.rsts_thumbs_imgSize

### DIFF
--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -441,7 +441,7 @@ $GLOBALS['TL_DCA']['tl_content']['fields']['rsts_thumbs_controls'] = array(
 	'sql' => "char(1) COLLATE ascii_bin NOT NULL default '1'",
 );
 $GLOBALS['TL_DCA']['tl_content']['fields']['rsts_thumbs_imgSize'] = array(
-	'label' => &$GLOBALS['TL_LANG']['tl_module']['imgSize'],
+	'label' => &$GLOBALS['TL_LANG']['MSC']['imgSize'],
 	'exclude' => true,
 	'inputType' => 'imageSize',
 	'options_callback' => function() {


### PR DESCRIPTION
…_imgSize']

The label for $GLOBALS['TL_DCA']['tl_content']['fields']['rsts_thumbs_imgSize'] refers to a language string "tl_module.imgSize" that is no longer available.